### PR TITLE
fix: test using @open-wc/testing

### DIFF
--- a/test/another-test.test.ts
+++ b/test/another-test.test.ts
@@ -1,24 +1,25 @@
+import {fixture, elementUpdated, expect} from '@open-wc/testing';
 import '@spectrum-web-components/card/sp-card.js';
-import { Card } from '@spectrum-web-components/card';
+import {Card} from '@spectrum-web-components/card';
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
 
 import {
-    smallHorizontal,
-    StoryArgs,
+  smallHorizontal,
+  StoryArgs,
 } from '../stories/index.js';
+
 
 describe('AnotherTest', () => {
   it.only('loads - [horizontal]', async () => {
     const el = await fixture<Card>(
-        smallHorizontal(smallHorizontal.args as StoryArgs)
+      smallHorizontal(smallHorizontal.args as StoryArgs)
     );
 
     await elementUpdated(el);
 
     await expect(el).to.be.accessible();
-});
+  });
 });


### PR DESCRIPTION
My suggestion, for your use case, is to do the import of `@open-wc/testing` elements in the first place. Doing this should be enough to make the test work properly avoiding the polyfill problem. We should probably document this.

Does it work for you?